### PR TITLE
Docker separate out downloading packages and building binary 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@
 FROM golang:1.13-buster AS builder
 
 WORKDIR /build/scim
+COPY go.mod ./
+COPY pkg/v2/go.mod ./pkg/v2/go.mod
+COPY mongo/v2/go.mod ./mongo/v2/go.mod
+COPY Makefile ./
+RUN make deps
 
 COPY . ./
-
-RUN make build
+RUN make binary
 
 ##########################################################################
 # FINAL IMAGE


### PR DESCRIPTION
This fix improves dev experience as a minor change to the code won't force re-downloading all packages.