### PR TITLE
Fix attribute query handling for extension schemas

### DIFF
--- a/pkg/v2/json/serialize.go
+++ b/pkg/v2/json/serialize.go
@@ -90,7 +90,7 @@ func (s *serializer) ShouldVisit(property prop.Property) bool {
 			test := strings.ToLower(property.Attribute().Path())
 			if len(s.includes) > 0 {
 				for _, include := range s.includes {
-					if include == test || strings.HasPrefix(include, test+".") || strings.HasPrefix(test, include+".") {
+					if include == test || strings.HasPrefix(include, test+".") || strings.HasPrefix(include, test+":") {
 						return !property.IsUnassigned()
 					}
 				}
@@ -110,7 +110,7 @@ func (s *serializer) ShouldVisit(property prop.Property) bool {
 		if len(s.includes) > 0 {
 			test := strings.ToLower(property.Attribute().Path())
 			for _, include := range s.includes {
-				if include == test || strings.HasPrefix(include, test+".") || strings.HasPrefix(test, include+".") {
+				if include == test || strings.HasPrefix(include, test+".") || strings.HasPrefix(include, test+":") {
 					return true
 				}
 			}

--- a/pkg/v2/json/serialize_test.go
+++ b/pkg/v2/json/serialize_test.go
@@ -44,8 +44,9 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
 				expect := `
 {
    "schemas":[
-      "urn:ietf:params:scim:schemas:core:2.0:User"
-   ],
+      "urn:ietf:params:scim:schemas:core:2.0:User",
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+	 ],
    "id":"3cc032f5-2361-417f-9e2f-bc80adddf4a3",
    "meta":{
       "resourceType":"User",
@@ -93,7 +94,10 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
          "type":"work",
          "display":"123-45679"
       }
-   ]
+   ],
+   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+   	  "employeeNumber": "1234567"
+   }
 }
 `
 				assert.JSONEq(t, expect, string(raw))
@@ -109,13 +113,15 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
 			},
 			options: []Options{
 				Include("emails.value", "emails.type"),
+				Include("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber"),
 			},
 			expect: func(t *testing.T, raw []byte, err error) {
 				assert.Nil(t, err)
 				expect := `
 {
    "schemas":[
-      "urn:ietf:params:scim:schemas:core:2.0:User"
+      "urn:ietf:params:scim:schemas:core:2.0:User",
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
    ],
    "id":"3cc032f5-2361-417f-9e2f-bc80adddf4a3",
    "emails":[
@@ -127,7 +133,10 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
          "value":"imulab@bar.com",
          "type":"home"
       }
-   ]
+   ],
+   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+   	  "employeeNumber": "1234567"
+   }
 }
 `
 				assert.JSONEq(t, expect, string(raw))
@@ -145,13 +154,15 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
 				Exclude("emails.type", "emails.value", "emails.primary"),
 				Exclude("phoneNumbers", "ims", "groups", "entitlements"),
 				Exclude("roles", "photos", "addresses", "x509Certificates"),
+				Exclude("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber"),
 			},
 			expect: func(t *testing.T, raw []byte, err error) {
 				assert.Nil(t, err)
 				expect := `
 {
    "schemas":[
-      "urn:ietf:params:scim:schemas:core:2.0:User"
+      "urn:ietf:params:scim:schemas:core:2.0:User",
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
    ],
    "id":"3cc032f5-2361-417f-9e2f-bc80adddf4a3",
    "meta":{
@@ -182,7 +193,8 @@ func (s *JsonSerializeTestSuite) TestSerialize() {
       {
          "display":"imulab@bar.com"
       }
-   ]
+   ],
+   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {}
 }
 `
 				assert.JSONEq(t, expect, string(raw))
@@ -244,6 +256,7 @@ func (s *JsonSerializeTestSuite) SetupSuite() {
 	s.resourceData = map[string]interface{}{
 		"schemas": []interface{}{
 			"urn:ietf:params:scim:schemas:core:2.0:User",
+			"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 		},
 		"id": "3cc032f5-2361-417f-9e2f-bc80adddf4a3",
 		"meta": map[string]interface{}{
@@ -292,6 +305,9 @@ func (s *JsonSerializeTestSuite) SetupSuite() {
 				"type":    "work",
 				"display": "123-45679",
 			},
+		},
+		"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": map[string]interface{}{
+			"employeeNumber": "1234567",
 		},
 	}
 }


### PR DESCRIPTION
The existing serialization code supports including and excluding attributes as required by RFC 7644 but does not handle "fully qualified" attributes that contain the URN prefix, i.e. `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber` because it expects that `.` is used as a separator instead of `:`.

This PR adds detection of `:` and updates the existing unit tests to capture this scenario.

Under RFC 7644, clients [are expected to request attributes from extension schemas in this form](https://datatracker.ietf.org/doc/html/rfc7644#section-3.9). It clarifies that the "attribute" query parameter should be composed of

> ... a comma-separated list of resource attribute names in standard attribute notation

Where the distinct "standard attribute notation" for extension attributes is further detailed [as follows](https://datatracker.ietf.org/doc/html/rfc7644#section-3.10):

> Clients MAY omit core schema attribute URN prefixes but SHOULD fully qualify extended attributes with the associated schema extension URN to avoid naming conflicts. For example, the attribute 'age' defined in "urn:ietf:params:scim:schemas:exampleCo:2.0:hr" is uniquely identified as "urn:ietf:params:scim:schemas:exampleCo:2.0:hr:age".