### PR TITLE
Fix Dockerfile GOARCH on Mac M1 chip (arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN make build
 # FINAL IMAGE
 ##########################################################################
 FROM debian:buster-slim
-
+ARG TARGETARCH
 # copy binary
-COPY --from=builder /build/scim/bin/linux_amd64/scim /usr/bin/scim
+COPY --from=builder /build/scim/bin/linux_${TARGETARCH}/scim /usr/bin/scim
 
 # copy public files
 COPY --from=builder /build/scim/public /usr/share/scim/public


### PR DESCRIPTION
GOARCH on Mac M1 chip machines is arm64. Adjust the build directory path dynamically through TARGETARCH